### PR TITLE
Remove deprecated @inject and FQCNs in SearchController

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -15,25 +15,28 @@
 
 namespace ID\indexedSearchAutocomplete\Controller;
 
+use ID\IndexedSearchAutocomplete\Service\SearchService;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\IndexedSearch\Domain\Repository\IndexSearchRepository;
+
 /**
  * EntryController
  */
-class SearchController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController {
+class SearchController extends ActionController {
 
     /**
      * Search repository
      *
-     * @var \TYPO3\CMS\IndexedSearch\Domain\Repository\IndexSearchRepository
+     * @var IndexSearchRepository
      */
-    protected $searchRepository = null;
+    protected $searchRepository;
     
      /**
       * Search functions
       * 
-      * @var ID\IndexedSearchAutocomplete\Service\SearchService
-      * @inject
+      * @var SearchService
       */
-    protected $searchService = null;
+    protected $searchService;
 
     /**
      * action search
@@ -54,5 +57,13 @@ class SearchController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
         foreach ($result as $key => $value) {
             $this->view->assign($key, $value);
         }
+    }
+    
+    /**
+     * @param SearchService $searchService
+     * @return void
+     */
+    public function injectSearchService(SearchService $searchService) {
+        $this->searchService = $searchService;
     }
 }


### PR DESCRIPTION
Hi Sebastian, 

just removed the deprecated @inject and also the FQCNs in SearchController.
As my IDE tells me that the initial assignment of `null` to the two properties in the code can be safely ignored I also removed them.

See here more info about the deprecated @inject annotation from the official TYPO3 changelog:
[Deprecation 82975](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Deprecation-82975-DeprecateUsageOfInjectWithNonPublicProperties.html)
