### PR TITLE
Add extension key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,10 @@
     "psr-4": {
       "ID\\IndexedSearchAutocomplete\\": "Classes"
     }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "indexed_search_autocomplete"
+    }
   }
 }


### PR DESCRIPTION
Adding the extra property and extension key to composer.json increases compatibility with future TYPO3 versions and avoids deprecation notices.

See https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra