### PR TITLE
Typoscript setup doesn't work for overwrite

### DIFF
--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -1,5 +1,5 @@
 plugin {
-    tx_indexedsearch_autocomplete {
+    tx_indexedsearchautocomplete {
         view {
             # cat=plugin.tx_indexedsearch_autocomplete/file; type=string; label=LLL:EXT:indexed_search_autocomplete/Resources/Private/Language/ExtConfTemplate.xlf:constants.templateFilePath
             templateRootPath = EXT:indexed_search_autocomplete/Resources/Private/Templates/

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,17 +1,17 @@
 plugin {
-    tx_indexedsearch_autocomplete {
+    tx_indexedsearchautocomplete {
         view {
             templateRootPaths {
                 0 = EXT:indexed_search_autocomplete/Resources/Private/Templates/
-                10 = {$plugin.tx_indexedsearch_autocomplete.view.templateRootPath}
+                10 = {$plugin.tx_indexedsearchautocomplete.view.templateRootPath}
             }
             partialRootPaths {
                 0 = EXT:indexed_search_autocomplete/Resources/Private/Partials/
-                10 = {$plugin.tx_indexedsearch_autocomplete.view.partialRootPath}
+                10 = {$plugin.tx_indexedsearchautocomplete.view.partialRootPath}
             }
             layoutRootPaths {
                 0 = EXT:indexed_search_autocomplete/Resources/Private/Layouts/
-                10 = {$plugin.tx_indexedsearch_autocomplete.view.layoutRootPath}
+                10 = {$plugin.tx_indexedsearchautocomplete.view.layoutRootPath}
             }
         }
     }
@@ -19,10 +19,10 @@ plugin {
 
 page {
     includeCSS {
-        indexedSearchAutocomplete = {$plugin.tx_indexedsearch_autocomplete.cssAutocompleteFile}
+        indexedSearchAutocomplete = {$plugin.tx_indexedsearchautocomplete.cssAutocompleteFile}
     }
     includeJSFooter {
-        indexedSearchAutocomplete = {$plugin.tx_indexedsearch_autocomplete.javaScriptAutocompleteFile}
+        indexedSearchAutocomplete = {$plugin.tx_indexedsearchautocomplete.javaScriptAutocompleteFile}
     }
 }
 


### PR DESCRIPTION
We tried to overwrite the templates and it doesn't work, so we headed into the debugger and got to following point:
![2022-04-22_14h34_34](https://user-images.githubusercontent.com/49792220/164715489-b8c1378c-4c77-43be-8f01-468b994f6342.png)
public/typo3/sysext/fluid/Classes/View/TemplatePaths.php::getContextSpecificViewConfiguration() L.95ff
There the signature gets calculated out of the extension key, so it doesn't find tx_indexedsearch_autocomplete, because it is composite to tx_indexedsearchautocomplete.

So this is now our working overwriting constants file:
![2022-04-22_14h40_24](https://user-images.githubusercontent.com/49792220/164716149-c750f593-0d6e-4fb0-8044-d3525cb524dd.png)

Would be cool for future integrators, that the namespace is correct, so they can copy paste the extension configuration 1:1

